### PR TITLE
Filesystem storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 env.sh
 stash-passport-demo
+data

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: node_js
 node_js:
-  - "iojs"
   - "4.1"
   - "4.0"
 before_install:

--- a/bin/loom
+++ b/bin/loom
@@ -71,25 +71,27 @@ if (argv.config) {
 
 loader.addAndNormalizeObject(argv, loaderAddOptions);
 
-var cached_config = null;
+var cachedConfig = null;
 module.exports = {
-  load: function(cb){
-    if(cached_config){
-      if(typeof cb == 'function'){
-        cb(null, cached_config);
+  load: function(cb) {
+    if (cachedConfig) {
+      if (typeof cb == 'function') {
+        cb(null, cachedConfig);
       }
-      return cached_config;
+      return cachedConfig;
     }
     else {
-      loader.load(function(err, config){
-        cached_config = config;
+      loader.load(function(err, config) {
+        cachedConfig = config;
         cb(err, config);
       });
     }
   },
-}
+};
 
-loader.load(function(error, config) {
-  if (error) throw error;
-  loom.run(config);
-});
+if (!module.parent) {
+  loader.load(function(error, config) {
+    if (error) throw error;
+    loom.run(config);
+  });
+}

--- a/bin/loom
+++ b/bin/loom
@@ -36,13 +36,18 @@ loader.addMapping({
   dbHost: 'db.host',
   dbPort: 'db.port',
   dbName: 'db.db',
-  dbLogsTable: 'db.logsTable',
-  dbMetaTable: 'db.metaTable',
+  storageLogsTable: 'storage.logsTable',
+  storageMetaTable: 'storage.metaTable',
+
+  storageDataDir: 'storage.dataDir',
+  storageTailTimeout: 'storage.tailTimeout',
+  storageCompress: 'storage.compress',
 });
 
 var configKeys = [
   'server',
   'db',
+  'storage',
   'tokens',
 ];
 

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -9,10 +9,21 @@ dbHost: 'localhost'
 dbPort: 28015
 # RethinkDB DB name, defaults to logs
 dbName: "logs"
-# RethinkDB table for storing actual logs
-dbLogsTable: "logs"
 # RethinkDB table for storing stream metadata
-dbMetaTable: "meta"
+storageMetaTable: "meta"
+
+# RethinkDB table for storing actual logs (Rethink Storage)
+storageLogsTable: "logs"
+
+# Path on file system for storing stream files. Defaults to "data"
+# storageDataDir: "data"
+
+# Timeout for tailing streams. Defaults to 30 seconds.
+# storageTailTimeout: 30s
+
+# File compression, defaults to true
+# storageCompress: true
+
 
 # API tokens
 tokens:

--- a/index.js
+++ b/index.js
@@ -11,6 +11,6 @@ module.exports.run = function run(config) {
   rethink.connect(config.db);
 
   server.listen(config.server.port, config.server.host, function() {
-    server.log.info('%s listening at %s', server.name, server.url);
+    server.log.info('%s listening at %s', server.server.name, server.server.url);
   });
 };

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -12,12 +12,12 @@ var BearerStrategy = require('passport-http-bearer').Strategy;
  * @return {Object} - auth lib with the '.auth' function to use
  *                    as the auth middleware with routes
  */
-module.exports = function(config){
+module.exports = function(config) {
   var authlib = {
     verify: function(token, done) {
       process.nextTick(function() {
         var user = {
-          token: token
+          token: token,
         };
 
         var found = config.tokens.indexOf(token) > -1;
@@ -35,9 +35,9 @@ module.exports = function(config){
   var tokenAuth = passport.authenticate('bearer', {session: false, failWithError: true});
 
   // auth middleware that only checks for token authentication if its configured
-  authlib.auth = function(req, res, next){
-    if(Array.isArray(config.tokens)){
-      return tokenAuth(req, res, function (err){
+  authlib.auth = function(req, res, next) {
+    if (Array.isArray(config.tokens)) {
+      return tokenAuth(req, res, function(err) {
         // This callback is only called when `failWithError` is
         // set. We need a custom callback here to call `next()` so
         // that Restify can log the end of the request properly (and
@@ -49,7 +49,7 @@ module.exports = function(config){
         // must set `err.statusCode` on the error otherwise it'll get
         // reset to 500 (even though the passport middleware already
         // set `res.statusCode` to 401 previously)
-        if(err){
+        if (err) {
           err.statusCode = err.status;
         }
 
@@ -59,7 +59,7 @@ module.exports = function(config){
     else {
       next();
     }
-  }
+  };
 
-  return authlib
+  return authlib;
 };

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -1,172 +1,184 @@
+'use strict';
+
 var co = require('co');
 
-var ArrayStreamStorage = require('../../models').ArrayStreamStorage
-var RethinkStorage = require('../../models').RethinkStorage
+// var ArrayStreamStorage = require('../../models').ArrayStreamStorage;
+var RethinkStorage = require('../../models').RethinkStorage;
 
-Storage = RethinkStorage
-//Storage = ArrayStreamStorage
+var Storage = RethinkStorage;
+// var Storage = ArrayStreamStorage;
 
-var active_streams = (function(){
-  var active =  new (require("events").EventEmitter)()
-  active.streams = {}
-  active.on("added", function(id){
-    active.streams[id] = true
-  })
-  active.on("removed", function(id){
-    delete active.streams[id]
-  })
+var logger = require('../../logger');
+var log = logger.getLogger().child({component: 'server'});
 
-  var color_index = 0
-  active.get_color = function(obj){
+var activeStreams = (function() {
+  var active = new (require('events').EventEmitter)();
+  active.streams = {};
+  active.on('added', function(id) {
+    log.info('Spy Stream added: ' + id);
+    active.streams[id] = true;
+  });
+  active.on('removed', function(id) {
+    log.info('Spy Stream removed: ' + id);
+    delete active.streams[id];
+  });
+
+  var colorIndex = 0;
+  active.get_color = function(obj) {
     var colors = [
-      "black", "red", "green", "yellow", "blue", "gray", "magenta", "cyan", "white",
-      //"bgBlack", "bgRed", "bgGreen", "bgYellow", "bgBlue", "bgMagenta", "bgCyan", "bgWhite"
-    ]
-    return colors[color_index++ % colors.length];
-  }
+      'black', 'red', 'green', 'yellow', 'blue', 'gray', 'magenta', 'cyan', 'white',
+    ];
+    return colors[colorIndex++ % colors.length];
+  };
 
-  return active
-})()
+  return active;
+})();
 
 var streams = {
-  create: function(req, res, next){
-    var metadata = req.header('x-stream-metadata')
+  create: function(req, res, next) {
+    var metadata = req.header('x-stream-metadata');
     try {
-      if(metadata){
-        metadata = JSON.parse(metadata)
+      if (metadata) {
+        metadata = JSON.parse(metadata);
       }
-    } catch (e){
-      req.log.warn({err: e, metadata}, "Failed to parse metadata header as JSON")
+    }
+    catch (e) {
+      req.log.warn({err: e, metadata}, 'Failed to parse metadata header as JSON');
     }
 
-    co(function* (){
-      var id = req.params.id || 'stream-server-' + +new Date()
-      req.log = req.log.child({sid: id}, true)
+    co(function* () {
+      var id = req.params.id || 'stream-server-' + +new Date();
+      req.log = req.log.child({sid: id}, true);
 
-      var storage = new Storage()
+      var storage = new Storage();
 
-      var stream = yield storage.loadStream(id)
-      if(stream){
+      var stream = yield storage.loadStream(id);
+      if (stream) {
         // stream id is already taken, see if force flag is specified
-        if(req.query.force !== 'true'){
-          var msg = `The stream with ID ${id} already exists.`
-          req.log.error(msg)
-          res.json({error: msg + ' Specify force=true query param to override.'})
-          return next()
-        } else {
+        if (req.query.force !== 'true') {
+          var msg = `The stream with ID ${id} already exists.`;
+          req.log.error(msg);
+          res.json({error: msg + ' Specify force=true query param to override.'});
+          return next();
+        }
+        else {
           // delete existing stream
-          req.log.info("deleting stream...")
-          yield storage.deleteStream(id)
-          req.log.info("stream deleted")
+          req.log.info('deleting stream...');
+          yield storage.deleteStream(id);
+          req.log.info('stream deleted');
 
-          res.header("x-stream-replaced", true)
+          res.header('x-stream-replaced', true);
         }
       }
 
       storage.saveStream(id, {
-        metadata: metadata
+        metadata: metadata,
       }, {
-        replace: req.query.force === 'true'
-      }).then(function(){
-        active_streams.emit("added", id)
+        replace: req.query.force === 'true',
+      }).then(function() {
+        activeStreams.emit('added', id);
 
         // allow time for spy hooks to take hold
-        setTimeout(function(){
-          req.pipe(storage.createWriteStream(id))
-        }, 10)
+        setTimeout(function() {
+          req.pipe(storage.createWriteStream(id));
+        }, 10);
 
-        req.on("end", function(){
-          req.log.info("producer stream ended")
-          res.end()
-          active_streams.emit("removed", id)
-          next && next()
-        })
+        req.on('end', function() {
+          req.log.info('producer stream ended');
+          res.end();
+          activeStreams.emit('removed', id);
+          if (next) { next(); }
+        });
 
-        req.log.info({metadata}, "created stream")
+        req.log.info({metadata}, 'created stream');
 
         res.writeHead(201, {
-          "x-stream-id": id,
-        })
-        res.flushHeaders()
-      })
-    }).catch(next)
+          'x-stream-id': id,
+        });
+        res.flushHeaders();
+      });
+    }).catch(next);
   },
 
-  get: function(req, res, next){
-    var streamId = req.params.id
-    var notail = 'notail' in req.query
+  get: function(req, res, next) {
+    var streamId = req.params.id;
+    var notail = 'notail' in req.query;
 
-    req.log = req.log.child({sid: streamId}, true)
-    req.log.info({opts: {notail: notail}}, "got a consumer request")
+    req.log = req.log.child({sid: streamId}, true);
+    req.log.info({opts: {notail: notail}}, 'got a consumer request');
 
-    var storage = new Storage()
-    storage.loadStream(streamId).then(function(stream){
-      if(!stream){
-        res.json({error: `The stream with ID ${streamId} does not exist`})
-        return next()
+    var storage = new Storage();
+    storage.loadStream(streamId).then(function(stream) {
+      if (!stream) {
+        res.json({error: `The stream with ID ${streamId} does not exist`});
+        return next();
       }
 
-      var reader = storage.createReadStream(streamId, {notail})
-      res.header('x-stream-metadata', JSON.stringify(stream.metadata))
+      var reader = storage.createReadStream(streamId, {notail});
+      res.header('x-stream-metadata', JSON.stringify(stream.metadata));
 
-      reader.pipe(res)
+      reader.pipe(res);
 
-      res.on('finish', function(){
-        req.log.info("consumer stream ended")
-        next()
-      })
-    }).catch(function(err){
-      req.log.error({err}, "Could not fetch stream")
-      res.json({error: err.message})
-      return next()
-    })
+      res.on('finish', function() {
+        req.log.info('consumer stream ended');
+        next();
+      });
+    }).catch(function(err) {
+      req.log.error({err}, 'Could not fetch stream');
+      res.json({error: err.message});
+      return next();
+    });
   },
 
   // dumps all active live streams
-  spy: function(req, res, next){
-    var colors = require('colors')
-    colors.supportsColor = colors.enabled = true // force support (needed when running with npm)
+  spy: function(req, res, next) {
+    var colors = require('colors');
+    // force support (needed when running with npm)
+    colors.supportsColor = colors.enabled = true;
 
-    function colorize(str, color){
-      if(req.query.color != undefined){
-        return colors[color](str).replace(/(^.*):/, "$&".bold)
+    function colorize(str, color) {
+      if (req.query.color !== void 0) {
+        return colors[color](str).replace(/(^.*):/, '$&'.bold);
       }
-      return str
+      return str;
     }
 
-    var through2 = require('through2')
-    var storage = new Storage()
+    var through2 = require('through2');
+    var storage = new Storage();
 
     var lastStreamId;
 
-    function showStream(id){
-      var color = active_streams.get_color()
-      res.write(colorize(`START: ${id}\n`, color))
+    function showStream(id) {
+      req.log.info('SHOW STREAM: ' + id);
 
-      var read_stream = storage.createReadStream(id)
+      var color = activeStreams.get_color();
+      res.write(colorize(`START: ${id}\n`, color));
 
-      read_stream.pipe(through2(function(chunk, enc, cb){
+      var readStream = storage.createReadStream(id);
+
+      readStream.pipe(through2(function(chunk, enc, cb) {
         // don't re-print stream ID header if the last chunk belonged to the same stream
         var header = `${id}:\n`;
-        if(lastStreamId === id){
-          header = ''
+        if (lastStreamId === id) {
+          header = '';
         }
         lastStreamId = id;
 
-        cb(null, colorize(`${header}${chunk.toString()}`, color))
-      })).pipe(res, {end: false})
+        cb(null, colorize(`${header}${chunk.toString()}`, color));
+      })).pipe(res, {end: false});
 
-      read_stream.on('end', function flush(cb){
-        res.write(colorize(`END: ${id}\n`, color))
-      })
+      readStream.on('end', function flush(cb) {
+        req.log.info('STREAM ENDED: ' + id);
+        res.write(colorize(`END: ${id}\n`, color));
+      });
     }
 
     // stream all in-flight streams
-    Object.keys(active_streams.streams).forEach(showStream)
+    Object.keys(activeStreams.streams).forEach(showStream);
 
     // stream all new streams
-    active_streams.on("added", showStream)
-  }
-}
+    activeStreams.on('added', showStream);
+  },
+};
 
-module.exports = {streams}
+module.exports = {streams};

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -3,7 +3,7 @@
 var co = require('co');
 
 // var ArrayStreamStorage = require('../../models').ArrayStreamStorage;
-var RethinkStorage = require('../../models').RethinkStorage;
+// var RethinkStorage = require('../../models').RethinkStorage;
 var FileSystemStorage = require('../../models').FileSystemStorage;
 
 // var Storage = RethinkStorage;

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -4,12 +4,21 @@ var co = require('co');
 
 // var ArrayStreamStorage = require('../../models').ArrayStreamStorage;
 var RethinkStorage = require('../../models').RethinkStorage;
+var FileSystemStorage = require('../../models').FileSystemStorage;
 
-var Storage = RethinkStorage;
+// var Storage = RethinkStorage;
 // var Storage = ArrayStreamStorage;
+var Storage = FileSystemStorage;
+
 
 var logger = require('../../logger');
 var log = logger.getLogger().child({component: 'server'});
+
+function handleError(res, err, next) {
+  res.status(err.status || 500);
+  res.json({error: err.message});
+  next();
+}
 
 var activeStreams = (function() {
   var active = new (require('events').EventEmitter)();
@@ -76,12 +85,33 @@ var streams = {
       }, {
         replace: req.query.force === 'true',
       }).then(function() {
-        activeStreams.emit('added', id);
+        var error;
+
+        var writer = storage.createWriteStream(id);
+
+        writer.on('error', (err) => {
+          req.log.error({err}, 'Failed to create writer stream for', id);
+
+          error = err;
+          handleError(res, err, next);
+        });
+
 
         // allow time for spy hooks to take hold
         setTimeout(function() {
-          req.pipe(storage.createWriteStream(id));
+          if (!error) {
+            req.pipe(writer);
+
+            req.log.info({metadata}, 'created stream');
+
+            res.writeHead(201, {
+              'x-stream-id': id,
+            });
+            res.flushHeaders();
+          }
         }, 10);
+
+        activeStreams.emit('added', id);
 
         req.on('end', function() {
           req.log.info('producer stream ended');
@@ -89,13 +119,6 @@ var streams = {
           activeStreams.emit('removed', id);
           if (next) { next(); }
         });
-
-        req.log.info({metadata}, 'created stream');
-
-        res.writeHead(201, {
-          'x-stream-id': id,
-        });
-        res.flushHeaders();
       });
     }).catch(next);
   },
@@ -117,6 +140,16 @@ var streams = {
       var reader = storage.createReadStream(streamId, {notail});
       res.header('x-stream-metadata', JSON.stringify(stream.metadata));
 
+      reader.on('error', (err) => {
+        req.log.error({err}, 'Failed to create read stream for', streamId);
+
+        if (err.code === 'ENOENT') {
+          err.status = 404;
+        }
+
+        handleError(res, err, next);
+      });
+
       reader.pipe(res);
 
       res.on('finish', function() {
@@ -125,8 +158,7 @@ var streams = {
       });
     }).catch(function(err) {
       req.log.error({err}, 'Could not fetch stream');
-      res.json({error: err.message});
-      return next();
+      handleError(res, err, next);
     });
   },
 
@@ -156,6 +188,10 @@ var streams = {
 
       var readStream = storage.createReadStream(id);
 
+      readStream.on('error', (err) => {
+        req.log.error({err}, 'Failed to create spy read stream for', id);
+      });
+
       readStream.pipe(through2(function(chunk, enc, cb) {
         // don't re-print stream ID header if the last chunk belonged to the same stream
         var header = `${id}:\n`;
@@ -170,6 +206,14 @@ var streams = {
       readStream.on('end', function flush(cb) {
         req.log.info('STREAM ENDED: ' + id);
         res.write(colorize(`END: ${id}\n`, color));
+      });
+
+      activeStreams.on('removed', function(removedId) {
+        if (id === removedId) {
+          // give the stream some time to finish being written and outputted
+          // not the best method, but this is non-critical code
+          setTimeout(() => readStream.end(), 200);
+        }
       });
     }
 

--- a/lib/api/controllers/index.js
+++ b/lib/api/controllers/index.js
@@ -47,10 +47,10 @@ var streams = {
     }
 
     co(function* () {
-      var id = req.params.id || 'stream-server-' + +new Date();
+      var id = req.params.id || 'loom-' + +new Date();
       req.log = req.log.child({sid: id}, true);
 
-      var storage = new Storage();
+      var storage = new Storage(req.loomConfig.storage);
 
       var stream = yield storage.loadStream(id);
       if (stream) {
@@ -107,7 +107,7 @@ var streams = {
     req.log = req.log.child({sid: streamId}, true);
     req.log.info({opts: {notail: notail}}, 'got a consumer request');
 
-    var storage = new Storage();
+    var storage = new Storage(req.loomConfig.storage);
     storage.loadStream(streamId).then(function(stream) {
       if (!stream) {
         res.json({error: `The stream with ID ${streamId} does not exist`});
@@ -144,7 +144,7 @@ var streams = {
     }
 
     var through2 = require('through2');
-    var storage = new Storage();
+    var storage = new Storage(req.loomConfig.storage);
 
     var lastStreamId;
 

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,8 +7,14 @@ module.exports.configure = function(server, config) {
     tokens: config.tokens,
   }).auth;
 
-  server.post('/stream/', auth, controllers.streams.create);
-  server.post('/stream/:id', auth, controllers.streams.create);
-  server.get('/stream/:id', auth, controllers.streams.get);
-  server.get('/spy', auth, controllers.streams.spy);
+  // inject server configuration into the controllers
+  var conf = function(req, res, next) {
+    req.loomConfig = config;
+    next();
+  };
+
+  server.post('/stream/', auth, conf, controllers.streams.create);
+  server.post('/stream/:id', auth, conf, controllers.streams.create);
+  server.get('/stream/:id', auth, conf, controllers.streams.get);
+  server.get('/spy', auth, conf, controllers.streams.spy);
 };

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -1,12 +1,14 @@
-var controllers = require('./controllers')
+'use strict';
 
-module.exports.configure = function (server, config){
+var controllers = require('./controllers');
+
+module.exports.configure = function(server, config) {
   var auth = require('./auth')({
-    tokens: config.tokens
-  }).auth
+    tokens: config.tokens,
+  }).auth;
 
-  server.post('/stream/', auth, controllers.streams.create)
-  server.post('/stream/:id', auth, controllers.streams.create)
-  server.get ('/stream/:id', auth, controllers.streams.get)
-  server.get ('/spy', auth, controllers.streams.spy)
-}
+  server.post('/stream/', auth, controllers.streams.create);
+  server.post('/stream/:id', auth, controllers.streams.create);
+  server.get('/stream/:id', auth, controllers.streams.get);
+  server.get('/spy', auth, controllers.streams.spy);
+};

--- a/lib/api/server.js
+++ b/lib/api/server.js
@@ -44,9 +44,7 @@ class Server {
 
     server.use(restify.queryParser({mapParams: false}));
 
-    routes.configure(server, {
-      tokens: config.tokens,
-    });
+    routes.configure(server, config);
 
     server.use(restify.queryParser({mapParams: false}));
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,22 +1,24 @@
-var http = require('http')
-var url = require('url')
+'use strict';
+
+var http = require('http');
+var url = require('url');
 
 /**
  * Create a client
  * @param {Object} config - Config object
  * @param {Object} config.url - url of server
  */
-function createClient(config){
-  config = config || {}
-  if(!config.url){
-    throw new Exception("url config required for client")
+function createClient(config) {
+  config = config || {};
+  if (!config.url) {
+    throw new Error('url config required for client');
   }
 
   return {
     config: config,
-    createWriteStream: function(metadata, opts){
-      if(opts.id){
-        opts.id = require('querystring').escape(opts.id)
+    createWriteStream: function(metadata, opts) {
+      if (opts.id) {
+        opts.id = require('querystring').escape(opts.id);
       }
 
       var client = http.request({
@@ -25,27 +27,27 @@ function createClient(config){
         method: 'post',
         path: '/stream' + (opts.id ? `/${opts.id}` : '') + (opts.force ? '?force=true' : ''),
         headers: {
-          connection: 'keep-alive',
-          'x-stream-metadata': JSON.stringify(metadata)
-        }
-      }, function(res){
-        res.pipe(process.stdout)
-      })
+          'connection': 'keep-alive',
+          'x-stream-metadata': JSON.stringify(metadata),
+        },
+      }, function(res) {
+        res.pipe(process.stdout);
+      });
 
       // disable connection timeout: let the output flow for as long as it wants
-      client.setTimeout(0)
+      client.setTimeout(0);
 
-      client.on("error", function(err){
-        console.error("socket closed: " + err.message)
-      })
+      client.on('error', function(err) {
+        console.error('socket closed: ' + err.message);
+      });
 
       // client.on("finish", function(){
       //   console.error("input finished")
       // })
 
-      return client
-    }
-  }
+      return client;
+    },
+  };
 }
 
-module.exports = createClient
+module.exports = createClient;

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,7 @@ function createClient(config) {
           'x-stream-metadata': JSON.stringify(metadata),
         },
       }, function(res) {
+        console.log(res.statusCode, res.statusMessage);
         res.pipe(process.stdout);
       });
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,7 @@
-var bunyan, logger;
+'use strict';
+
+var bunyan;
+var logger;
 
 bunyan = require('bunyan');
 
@@ -9,18 +12,18 @@ logger = bunyan.createLogger({
   serializers: bunyan.stdSerializers,
   streams: [
     {
-      stream: process.stdout
-    }
-  ]
+      stream: process.stdout,
+    },
+  ],
 });
 
 module.exports = {
   getLogger: function(component) {
-    if(component) {
-      return logger.child({component: component})
+    if (component) {
+      return logger.child({component: component});
     }
     else {
       return logger;
     }
-  }
+  },
 };

--- a/lib/models/array_stream_storage.js
+++ b/lib/models/array_stream_storage.js
@@ -1,71 +1,71 @@
-"use strict"
+'use strict';
 
-var through = require('through2')
-var combine = require('stream-combiner')
+var through = require('through2');
 
-var meta_store = {}
+var metaStore = {};
 
 class ArrayStreamStorage {
-  constructor(){
-    this._store = meta_store
+  constructor() {
+    this._store = metaStore;
   }
 
-  createWriteStream(streamId){
-    var conf = meta_store[streamId]
-    if(!conf){
-      return null
+  createWriteStream(streamId) {
+    var conf = metaStore[streamId];
+    if (!conf) {
+      return null;
     }
 
     var writeStream = through(function(data, enc, cb) {
-      if(!conf.buffering){
-        this.push(data)
+      if (!conf.buffering) {
+        this.push(data);
       }
 
-      conf.buffer.push(data)
-      cb()
-    }, function flush(cb){
+      conf.buffer.push(data);
+      cb();
+    }, function flush(cb) {
       // write terminator
-      this.push(null)
+      this.push(null);
       conf.buffer.push(null);
-      cb()
-    })
+      cb();
+    });
 
     writeStream.pipe(conf.stream);
 
     return writeStream;
   }
 
-  createReadStream(streamId){
-    var conf = meta_store[streamId]
-    if(!conf){
-      return null
+  createReadStream(streamId) {
+    var conf = metaStore[streamId];
+    if (!conf) {
+      return null;
     }
 
     var readStream = through();
-    for (var i in conf.buffer) {
-      readStream.push(conf.buffer[i])
+    for (let buffer of conf.buffer) {
+      readStream.push(buffer);
     }
 
-    conf.buffering = false
-    conf.stream.pipe(readStream)
+    conf.buffering = false;
+    conf.stream.pipe(readStream);
 
     return readStream
-      .pipe(through(function(data, enc, cb){
-        if(data === null){
-          this.end()
-          cb()
-        } else {
-          cb(null, data)
+      .pipe(through(function(data, enc, cb) {
+        if (data === null) {
+          this.end();
+          cb();
+        }
+        else {
+          cb(null, data);
         }
       }));
   }
 
-  saveStream(streamId, meta, opts, cb){
-    if(typeof opts == 'function'){
-      cb = opts
-      opts = false
+  saveStream(streamId, meta, opts, cb) {
+    if (typeof opts == 'function') {
+      cb = opts;
+      opts = false;
     }
-    opts = opts || {}
+    opts = opts || {};
 
     var conf = {
       meta: meta,
@@ -74,39 +74,39 @@ class ArrayStreamStorage {
 
       // until we have a reader and the stream is being consumed, only buffer values,
       // don't add them into the stream or we'll get duplicates
-      buffering: true
-    }
-    meta_store[streamId] = conf
+      buffering: true,
+    };
+    metaStore[streamId] = conf;
 
-    cb && cb(null, meta)
-    return Promise.resolve(meta)
+    if (cb) { cb(null, meta); }
+    return Promise.resolve(meta);
   }
 
-  loadStream(streamId, cb){
-    var conf = meta_store[streamId]
-    var ret = null
+  loadStream(streamId, cb) {
+    var conf = metaStore[streamId];
+    var ret = null;
 
-    // console.log(JSON.stringify({meta_store}, null, 2))
+    // console.log(JSON.stringify({metaStore}, null, 2))
 
-    if(conf){
-      ret = conf.meta
-      this._array_buffer = conf.buffer
+    if (conf) {
+      ret = conf.meta;
+      this._array_buffer = conf.buffer;
     }
 
     // console.log(`found meta for id ${streamId}:`, meta)
     // console.log("found metadata:", ret)
 
-    cb && cb(null, ret)
-    return Promise.resolve(ret)
+    if (cb) { cb(null, ret); }
+    return Promise.resolve(ret);
   }
 
-  deleteStream(streamId, cb){
+  deleteStream(streamId, cb) {
     // "delete" the data for this stream
-    delete meta_store[streamId]
+    delete metaStore[streamId];
 
-    cb && cb(null, true)
-    return Promise.resolve(true)
+    if (cb) { cb(null, true); }
+    return Promise.resolve(true);
   }
 }
 
-module.exports = ArrayStreamStorage
+module.exports = ArrayStreamStorage;

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,9 +1,9 @@
-"use strict"
+'use strict';
 
-var ArrayStreamStorage = require('./array_stream_storage')
-var RethinkStorage = require('./rethink_storage')
+var ArrayStreamStorage = require('./array_stream_storage');
+var RethinkStorage = require('./rethink_storage');
 
 module.exports = {
   ArrayStreamStorage,
   RethinkStorage,
-}
+};

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -2,8 +2,10 @@
 
 var ArrayStreamStorage = require('./array_stream_storage');
 var RethinkStorage = require('./rethink_storage');
+var FileSystemStorage = require('./rethink_stream_backend_filesystem');
 
 module.exports = {
   ArrayStreamStorage,
   RethinkStorage,
+  FileSystemStorage,
 };

--- a/lib/models/rethink_storage.js
+++ b/lib/models/rethink_storage.js
@@ -16,9 +16,7 @@ class RethinkStorage {
    * @param [config.logsTable="logs"] - Rethinkdb table to use for log data. Defaults to "logs"
    */
   constructor(config) {
-    // super()
-
-    this.config = _.defaults(config || {}, {
+    this.config = _.defaults({}, config, {
       logsTable: 'logs',
       metaTable: 'meta',
     });

--- a/lib/models/rethink_storage.js
+++ b/lib/models/rethink_storage.js
@@ -1,61 +1,58 @@
-"use strict"
+'use strict';
 
-var _ = require('lodash')
-var through = require('through2')
-var multistream = require('multistream')
-var combine = require('stream-combiner')
-var JSONStream = require('JSONStream')
-var Throttle = require('stream-throttle').Throttle
+var _ = require('lodash');
+var through = require('through2');
 
 // connect to localhost on default port with a connection pool
-var rethink = require('../rethink')
+var rethink = require('../rethink');
 
 var logger = require('../logger');
 
 class RethinkStorage {
+
   /**
    * @param config - Config object
    * @param [config.metaTable="meta"] - Rethinkdb table to use for metadata. Defaults to "meta"
    * @param [config.logsTable="logs"] - Rethinkdb table to use for log data. Defaults to "logs"
    */
-  constructor(config){
+  constructor(config) {
     // super()
 
     this.config = _.defaults(config || {}, {
-      logsTable: "logs",
-      metaTable: "meta"
-    })
+      logsTable: 'logs',
+      metaTable: 'meta',
+    });
 
     this.log = logger.getLogger();
   }
 
-  createWriteStream(streamId){
-    var self = this
+  createWriteStream(streamId) {
+    var self = this;
 
     // write data buffer to the DB, along with the stream id and a timestamp
-    var insert_data = function(data, cb){
+    var insertData = function(data, cb) {
       rethink.r.table(self.config.logsTable).insert({
         sid: streamId,
         data,
         ts: new Date(),
-      }).run(function(err){
-        cb(err)
-      })
-    }
+      }).run(function(err) {
+        cb(err);
+      });
+    };
 
     // create a stream that writes data to the db
     // when the stream ends, write `null` for the data to signify end of stream
-    var stream = through(function(data, enc, cb){
-      insert_data(data, cb)
-    }, function flush(cb){
+    var stream = through(function(data, enc, cb) {
+      insertData(data, cb);
+    }, function flush(cb) {
       // write terminator
-      insert_data(null, cb)
-    })
+      insertData(null, cb);
+    });
 
-    return stream
+    return stream;
   }
 
-  createReadStream(streamId, opts){
+  createReadStream(streamId, opts) {
     var self = this;
     opts = opts || {};
     var notail = opts.notail;
@@ -193,47 +190,47 @@ class RethinkStorage {
     return stream;
   }
 
-  saveStream(streamId, meta, opts, cb){
-    if(typeof opts == 'function'){
-      cb = opts
-      opts = false
+  saveStream(streamId, meta, opts, cb) {
+    if (typeof opts == 'function') {
+      cb = opts;
+      opts = false;
     }
-    opts = opts || {}
+    opts = opts || {};
 
     // no truthiness here, only the real 'true' will do
-    var conflict = opts.replace === true ? 'replace' : 'error'
+    var conflict = opts.replace === true ? 'replace' : 'error';
 
     // save the metadata of this stream
     var stream = {
       id: streamId,
-      meta: meta
-    }
-    return rethink.r.table(this.config.metaTable).insert(stream, {conflict: conflict}).run(cb)
+      meta: meta,
+    };
+    return rethink.r.table(this.config.metaTable).insert(stream, {conflict: conflict}).run(cb);
   }
 
-  loadStream(streamId, cb){
+  loadStream(streamId, cb) {
     // load the metadata of this stream
     return rethink.r.table(this.config.metaTable).get(streamId).run()
-      .then(function(stream){
-        cb && cb(stream && stream.meta)
-        return stream && stream.meta
-      }).catch(cb)
+      .then(function(stream) {
+        if (cb) { cb(stream && stream.meta); }
+        return stream && stream.meta;
+      }).catch(cb);
   }
 
-  deleteStream(streamId, cb){
+  deleteStream(streamId, cb) {
     // "delete" the data for this stream
     // (not the metadata - that will get overwritten on save)
 
-    var new_sid_postfix = '_' + +new Date()
+    var newSidPostfix = '_' + +new Date();
     return rethink.r.table(this.config.logsTable)
       .filter({sid: streamId})
       .update({
-        sid: rethink.r.row("sid").add(new_sid_postfix),
-        origSid: rethink.r.row("sid")
+        sid: rethink.r.row('sid').add(newSidPostfix),
+        origSid: rethink.r.row('sid'),
       })
-      .run(cb)
+      .run(cb);
   }
 }
 
-module.exports = RethinkStorage
+module.exports = RethinkStorage;
 

--- a/lib/models/rethink_stream_backend_filesystem.js
+++ b/lib/models/rethink_stream_backend_filesystem.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 
+var through2 = require('through2');
 var _ = require('lodash');
 
 var createTailingStream = require('tailing-stream').createReadStream;
@@ -39,8 +40,6 @@ class FileSystemStorage extends RethinkStorage {
     var path = this.makeStreamFilePath(streamId);
     var stream = fs.createWriteStream(path);
 
-    // TODO: do we need an EOF terminator marker?
-
     return stream;
   }
 
@@ -49,19 +48,33 @@ class FileSystemStorage extends RethinkStorage {
     var notail = opts.notail;
 
     var path = this.makeStreamFilePath(streamId);
-    var stream;
+    var stream = through2();
 
-    if (notail) {
-      // with notail option, just read the file to the current end
-      stream = fs.createReadStream(path);
-    }
-    else {
-      // otherwise, tail the file
-      // keep reading until we see an EOF, or a timeout is hit
-      stream = createTailingStream(path, {
-        timeout: this.config.tailTimeout,
-      });
-    }
+    // a finished stream implies notail option
+    this._isStreamFinished(path, (err, finished) => {
+      if (err) {
+        return stream.emit('error', err);
+      }
+
+      if (finished) {
+        notail = true;
+      }
+
+      var dataStream;
+      if (notail) {
+        // with notail option, just read the file to the current end
+        dataStream = fs.createReadStream(path);
+      }
+      else {
+        // otherwise, tail the file
+        // keep reading until we see an EOF, or a timeout is hit
+        dataStream = createTailingStream(path, {
+          timeout: this.config.tailTimeout,
+        });
+      }
+
+      dataStream.pipe(stream);
+    });
 
     return stream;
   }
@@ -79,6 +92,24 @@ class FileSystemStorage extends RethinkStorage {
       cb(err, newPath);
     });
   }
+
+  /**
+   * Checks to see if the stream has finished writing.
+   * This is done by checking if the modified timestamp of the file is older than tailTimeout
+   * @param String filePath - path to the file to check
+   * @param Function cb - callback called with true or false, and an age in ms: function(err, boolean, {age})
+   */
+  _isStreamFinished(filePath, cb) {
+    fs.stat(filePath, (err, stat) => {
+      if (err) return cb(err);
+
+      var age = +new Date() - stat.mtime;
+      var finished = age > this.config.tailTimeout;
+
+      cb(null, finished, {age: age});
+    });
+  }
+
 }
 
 module.exports = FileSystemStorage;

--- a/lib/models/rethink_stream_backend_filesystem.js
+++ b/lib/models/rethink_stream_backend_filesystem.js
@@ -1,0 +1,85 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var _ = require('lodash');
+
+var createTailingStream = require('tailing-stream').createReadStream;
+
+var RethinkStorage = require('./rethink_storage');
+
+class FileSystemStorage extends RethinkStorage {
+
+  /**
+   * @param config - Config object
+   * @param [config.metaTable="meta"] - Rethinkdb table to use for metadata. Defaults to "meta"
+   * @param [config.dataDir="data"] - Path on file system for storing stream files. Defaults to "data"
+   * @param [config.tailTimeout=30000] - Timeout for tailing streams. Defaults to 30 seconds.
+   */
+  constructor(config) {
+    config = _.defaults({}, config, {
+      dataDir: 'data',
+      tailTimeout: 30 * 1000,
+    });
+
+    super(config);
+  }
+
+  makeFileName(streamId) {
+    return `stream-${streamId}.log`;
+  }
+
+  makeStreamFilePath(streamId, makeFileName) {
+    makeFileName = makeFileName || this.makeFileName;
+    return path.join(this.config.dataDir, makeFileName(streamId));
+  }
+
+  createWriteStream(streamId) {
+    var path = this.makeStreamFilePath(streamId);
+    var stream = fs.createWriteStream(path);
+
+    // TODO: do we need an EOF terminator marker?
+
+    return stream;
+  }
+
+  createReadStream(streamId, opts) {
+    opts = opts || {};
+    var notail = opts.notail;
+
+    var path = this.makeStreamFilePath(streamId);
+    var stream;
+
+    if (notail) {
+      // with notail option, just read the file to the current end
+      stream = fs.createReadStream(path);
+    }
+    else {
+      // otherwise, tail the file
+      // keep reading until we see an EOF, or a timeout is hit
+      stream = createTailingStream(path, {
+        timeout: this.config.tailTimeout,
+      });
+    }
+
+    return stream;
+  }
+
+  deleteStream(streamId, cb) {
+    // "delete" the data for this stream
+    // (not the metadata - that will get overwritten on save)
+
+    var newSidPrefix = `deleted_${+new Date()}_`;
+
+    var oldPath = this.makeStreamFilePath(streamId);
+    var newPath = this.makeStreamFilePath(streamId, (sid) => newSidPrefix + this.makeFileName(sid));
+
+    fs.rename(oldPath, newPath, (err) => {
+      cb(err, newPath);
+    });
+  }
+}
+
+module.exports = FileSystemStorage;
+

--- a/lib/models/rethink_stream_backend_filesystem.js
+++ b/lib/models/rethink_stream_backend_filesystem.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 var zlib = require('zlib');
+var ms = require('ms');
 
 var through2 = require('through2');
 var combine = require('bun');
@@ -28,7 +29,12 @@ class FileSystemStorage extends RethinkStorage {
       compress: true,
     });
 
+    // convert a string representation (e.g., 30000, 30s) to a number
+    config.tailTimeout = ms(config.tailTimeout + '');
+
     super(config);
+
+    // this.log.debug({config}, 'FileSystemStorage config');
   }
 
   makeFileName(streamId) {
@@ -61,7 +67,7 @@ class FileSystemStorage extends RethinkStorage {
     var stream = through2();
 
     // a finished stream implies notail option
-    this._isStreamFinished(path, (err, finished) => {
+    this._isStreamFinished(path, (err, finished, info) => {
       if (err) {
         return stream.emit('error', err);
       }
@@ -77,7 +83,7 @@ class FileSystemStorage extends RethinkStorage {
       }
       else {
         // otherwise, tail the file
-        // keep reading until we see an EOF, or a timeout is hit
+        // keep reading until we a timeout is hit
         dataStream = createTailingStream(path, {
           timeout: this.config.tailTimeout,
         });

--- a/lib/models/rethink_stream_backend_filesystem.js
+++ b/lib/models/rethink_stream_backend_filesystem.js
@@ -2,8 +2,10 @@
 
 var fs = require('fs');
 var path = require('path');
+var zlib = require('zlib');
 
 var through2 = require('through2');
+var combine = require('bun');
 var _ = require('lodash');
 
 var createTailingStream = require('tailing-stream').createReadStream;
@@ -17,11 +19,13 @@ class FileSystemStorage extends RethinkStorage {
    * @param [config.metaTable="meta"] - Rethinkdb table to use for metadata. Defaults to "meta"
    * @param [config.dataDir="data"] - Path on file system for storing stream files. Defaults to "data"
    * @param [config.tailTimeout=30000] - Timeout for tailing streams. Defaults to 30 seconds.
+   * @param [config.compressed=true] - Boolean value for transparrent on-disk compression
    */
   constructor(config) {
     config = _.defaults({}, config, {
       dataDir: 'data',
       tailTimeout: 30 * 1000,
+      compress: true,
     });
 
     super(config);
@@ -38,8 +42,14 @@ class FileSystemStorage extends RethinkStorage {
 
   createWriteStream(streamId) {
     var path = this.makeStreamFilePath(streamId);
-    var stream = fs.createWriteStream(path);
+    var fileStream = fs.createWriteStream(path);
+    var streams = [fileStream];
 
+    if (this.config.compress) {
+      streams.unshift(zlib.createGzip());
+    }
+
+    var stream = combine(streams);
     return stream;
   }
 
@@ -71,6 +81,10 @@ class FileSystemStorage extends RethinkStorage {
         dataStream = createTailingStream(path, {
           timeout: this.config.tailTimeout,
         });
+      }
+
+      if (this.config.compress) {
+        dataStream = dataStream.pipe(zlib.createGunzip());
       }
 
       dataStream.pipe(stream);

--- a/lib/models/rethink_stream_backend_filesystem.js
+++ b/lib/models/rethink_stream_backend_filesystem.js
@@ -19,7 +19,7 @@ class FileSystemStorage extends RethinkStorage {
    * @param [config.metaTable="meta"] - Rethinkdb table to use for metadata. Defaults to "meta"
    * @param [config.dataDir="data"] - Path on file system for storing stream files. Defaults to "data"
    * @param [config.tailTimeout=30000] - Timeout for tailing streams. Defaults to 30 seconds.
-   * @param [config.compressed=true] - Boolean value for transparrent on-disk compression
+   * @param [config.compress=true] - Boolean value for transparrent on-disk compression
    */
   constructor(config) {
     config = _.defaults({}, config, {
@@ -103,8 +103,9 @@ class FileSystemStorage extends RethinkStorage {
     var newPath = this.makeStreamFilePath(streamId, (sid) => newSidPrefix + this.makeFileName(sid));
 
     fs.rename(oldPath, newPath, (err) => {
-      cb(err, newPath);
+      if (cb) { cb(err, newPath); }
     });
+    return Promise.resolve(newPath);
   }
 
   /**

--- a/lib/rethink.js
+++ b/lib/rethink.js
@@ -1,7 +1,7 @@
-"use strict"
+'use strict';
 
-var _ = require('lodash')
-var log = require('./logger').getLogger('db')
+var _ = require('lodash');
+var log = require('./logger').getLogger('db');
 
 /**
  * .thinky, .r, .models, and .config get automatically set on connect()
@@ -12,42 +12,42 @@ var rethink = {
   config: null,
   models: null,
 
-  connect: function(config){
+  connect: function(config) {
     rethink.config = _.defaults(config || {}, {
-      logsTable: "logs",
-      metaTable: "meta"
+      logsTable: 'logs',
+      metaTable: 'meta',
     });
 
     var thinky = rethink.thinky = require('thinky')({
       host: config.host,
       port: config.port,
-      db: config.db
-    })
+      db: config.db,
+    });
 
     // grab instance of the driver
-    var r = rethink.r = thinky.r
+    var r = rethink.r = thinky.r;
 
     // log whenever the # of connections in the pool changes
     r.getPoolMaster().on('size', function(size) {
-      log.debug({pool_size: size}, `# of connections in pool: ${size}`)
+      log.debug({pool_size: size}, `# of connections in pool: ${size}`);
     });
 
-    rethink.models = createModels(thinky, config)
+    rethink.models = createModels(thinky, config);
 
-    return rethink
-  }
+    return rethink;
+  },
+};
+
+function createModels(thinky, config) {
+  var Logs = thinky.createModel(config.logsTable, {}, {enforce_extra: 'none'});
+  Logs.ensureIndex('ts');
+  Logs.ensureIndex('sid');
+  Logs.ensureIndex('sid_ts', function(row) { return [row('sid'), row('ts')]; });
+
+  var Meta = thinky.createModel(config.metaTable, {}, {enforce_extra: 'none'});
+
+  return {Logs, Meta};
 }
 
-function createModels(thinky, config){
-  var Logs = thinky.createModel(config.logsTable, {}, {enforce_extra: 'none'})
-  Logs.ensureIndex('ts')
-  Logs.ensureIndex('sid')
-  Logs.ensureIndex('sid_ts', function (row) { return [row("sid"), row("ts")] } )
 
-  var Meta = thinky.createModel(config.metaTable, {}, {enforce_extra: 'none'})
-
-  return {Logs, Meta}
-}
-
-
-module.exports = rethink
+module.exports = rethink;

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,10 +1,12 @@
+'use strict';
+
 var util = require('util');
 var _ = require('lodash');
 
 // var validator = require('validator');
 // var validator = require('validate.js');
 
-var validate = function(validation){
+var validate = function(validation) {
   // validation:
   // {
   //   'field': {
@@ -14,54 +16,54 @@ var validate = function(validation){
   //   'x': {isInt: true, isRequired: true}
   // }
 
-  var custom_validators = {
+  var customValidators = {
     // value is an array, value is a single value or array
-    isIn: function(value, target){
-      if(!Array.isArray(value)){
+    isIn: function(value, target) {
+      if (!Array.isArray(value)) {
         value = [value];
       }
 
-      if(_.difference(value, target).length > 0){
-        return false
+      if (_.difference(value, target).length > 0) {
+        return false;
       }
 
       return true;
     },
 
-    keysIn: function(value, target){
+    keysIn: function(value, target) {
       var keys = Object.keys(value);
 
-      return custom_validators.isIn(keys, target);
+      return customValidators.isIn(keys, target);
     },
 
-    hasKeys: function(value, target){
+    hasKeys: function(value, target) {
       var keys = Object.keys(value);
 
-      return custom_validators.isIn(target, keys);
-    }
-  }
+      return customValidators.isIn(target, keys);
+    },
+  };
 
-  return function(input){
-    var have_errors = false;
+  return function(input) {
+    var haveErrors = false;
     var errors = [];
 
-    var default_template = "%(field) validation failed, expected %(value) %(validator) %(expected)";
+    var defaultTemplate = '%(field) validation failed, expected %(value) %(validator) %(expected)';
 
     // content: {field, value, validator, expected}
-    function formatMessage(template, content){
-      template = template || default_template;
+    function formatMessage(template, content) {
+      template = template || defaultTemplate;
 
       var replacements = {
-        "%(field)": 'field',
-        "%(value)": 'value',
-        "%(validator)": 'validator',
-        "%(expected)": 'expected'
-      }
+        '%(field)': 'field',
+        '%(value)': 'value',
+        '%(validator)': 'validator',
+        '%(expected)': 'expected',
+      };
 
-      _.forOwn(replacements, function(key, variable){
-        if( content[key] ){
+      _.forOwn(replacements, function(key, variable) {
+        if (content[key]) {
           var value = content[key];
-          if(_.isObject(value)){
+          if (_.isObject(value)) {
             value = JSON.stringify(value);
           }
           template = template.replace(variable, value);
@@ -71,8 +73,8 @@ var validate = function(validation){
       return template;
     }
 
-    function addError(field, error){
-      have_errors = true;
+    function addError(field, error) {
+      haveErrors = true;
       errors.push({field: field, message: error});
     }
 
@@ -80,39 +82,39 @@ var validate = function(validation){
     _.forOwn(input, function(value, key) {
       // console.log("[input] key:", key, "value:", value);
       _.forOwn(validation, function(validatorProps, fieldName) {
-        if(fieldName !== key) return;
+        if (fieldName !== key) return;
 
         // console.log("\t[validation] fieldName:", fieldName, "validatorProps:", validatorProps);
         _.forOwn(validatorProps, function(expectedValue, validatorName) {
           // console.log("\t\t[validatorProps] validatorName:", validatorName, "expected:", expectedValue);
 
           // skip 'message'
-          if(validatorName === 'message') return;
+          if (validatorName === 'message') return;
 
-          var validatorFn = custom_validators[validatorName];
+          var validatorFn = customValidators[validatorName];
 
-          if(!validatorFn){
-            return addError(key, util.format("Validator doesn't exist: %s", validatorName));
+          if (!validatorFn) {
+            return addError(key, util.format('Validator doesn\'t exist: %s', validatorName));
           }
 
           // console.log("checking", fieldName, "value", value, "against", expectedValue);
           var valid = validatorFn(value, expectedValue);
 
-          if(!valid){
+          if (!valid) {
             // TODO: move message from validatorProps to validatorFn/object
             addError(key, formatMessage(validatorProps.message, {
               field: fieldName,
               value: value,
               expected: expectedValue,
-              validator: validatorName
+              validator: validatorName,
             }));
           }
         });
       });
     });
 
-    return have_errors && errors;
-  }
-}
+    return haveErrors && errors;
+  };
+};
 
 module.exports = validate;

--- a/migrations/0001-rethink-to-file-streams.js
+++ b/migrations/0001-rethink-to-file-streams.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// Run as:
+// node migrations/0001-rethink-to-file-streams -c loom.yaml | bunyan
+
+var loader = require('../bin/loom');
+var log = require('../lib/logger').getLogger('migration 0001');
+var rethink = require('../lib/rethink');
+var co = require('co');
+var fs = require('fs');
+
+var RethinkStorage = require('../lib/models').RethinkStorage;
+var FileSystemStorage = require('../lib/models').FileSystemStorage;
+
+var listRethinkStreams = function(cb) {
+  var Meta = rethink.models.Meta;
+  Meta.run(function(err, streams) {
+    if (err) { return cb(err); }
+
+    cb(null, streams.map((s)=>s.id));
+  });
+};
+
+// returns a promise that resolves to true or false
+var fileExists = function(path) {
+  return new Promise(function(accept, reject) {
+    fs.access(path, (err) => {
+      accept(!err);
+    });
+  });
+};
+
+// returns a promise that resoslves when src if fully written to dest
+var writeStream = function(src, dest) {
+  return new Promise(function(accept, reject) {
+    src
+      .pipe(dest)
+      .on('finish', accept)
+      .on('error', reject);
+  });
+};
+
+
+loader.load(function(err, config) {
+  log.info(config, 'using config:');
+
+  try {
+    rethink.connect(config.db);
+    var rethinkStorage = new RethinkStorage(config.storage);
+    var fileStorage = new FileSystemStorage(config.storage);
+
+    listRethinkStreams(function(err, streamIds) {
+      if (err) {
+        return log.error(err);
+      }
+
+      co(function*() {
+        for (let id of streamIds) {
+          let path = fileStorage.makeStreamFilePath(id);
+          var exists = yield fileExists(path);
+
+          if (exists) {
+            log.info(`exists, skipping:  ${path}`);
+          }
+          else {
+            log.info(`writing stream to: ${path}`);
+            yield writeStream(
+              rethinkStorage.createReadStream(id, {notail: true}),
+              fileStorage.createWriteStream(id)
+            );
+          }
+        }
+
+        setTimeout(()=> rethink.thinky.r.getPool().drain(), 1000);
+      }).catch(function(err) {
+        console.error(err.stack);
+      });
+    });
+  }
+  catch (e) {
+    console.error(e.stack);
+  }
+});
+
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "spy": "curl --no-buffer localhost:3060/spy?color"
   },
   "dependencies": {
+    "bun": "0.0.11",
     "bunyan": "^1.4.0",
     "co": "^4.6.0",
     "colors": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,18 +23,14 @@
     "spy": "curl --no-buffer localhost:3060/spy?color"
   },
   "dependencies": {
-    "JSONStream": "^1.0.4",
     "bunyan": "^1.4.0",
     "co": "^4.6.0",
     "colors": "^1.1.2",
     "lodash": "^3.10.1",
     "memorystream": "^0.3.1",
-    "multistream": "^2.0.2",
     "passport": "^0.2.2",
     "passport-http-bearer": "^1.0.1",
     "restify": "^4.0.0",
-    "stream-combiner": "^0.2.2",
-    "stream-throttle": "^0.1.3",
     "thinky": "^2.2.4",
     "through2": "^2.0.0",
     "yaml-config-loader": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "temp": "^0.8.3"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha -t 8000 --require should --recursive",
-    "watch": "./node_modules/.bin/mocha -w -t 8000 --require should --recursive",
+    "test": "./node_modules/.bin/mocha -t 12000 --require should --recursive",
+    "watch": "./node_modules/.bin/mocha -w -t 12000 --require should --recursive",
     "_test": "./node_modules/.bin/mocha -w --no-timeouts --require should --recursive",
     "start": "./bin/loom",
     "startdev": "nodemon ./bin/loom | ./node_modules/.bin/bunyan #-o short",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eslint-config-probo": "^1.0.2",
     "mocha": "^2.3.4",
     "should": "^7.0.4",
-    "supertest": "^1.1.0"
+    "supertest": "^1.1.0",
+    "temp": "^0.8.3"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha -t 8000 --require should --recursive",
@@ -31,6 +32,7 @@
     "passport": "^0.2.2",
     "passport-http-bearer": "^1.0.1",
     "restify": "^4.0.0",
+    "tailing-stream": "^0.2.0",
     "thinky": "^2.2.4",
     "through2": "^2.0.0",
     "yaml-config-loader": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "colors": "^1.1.2",
     "lodash": "^3.10.1",
     "memorystream": "^0.3.1",
+    "ms": "^0.7.1",
     "passport": "^0.2.2",
     "passport-http-bearer": "^1.0.1",
     "restify": "^4.0.0",

--- a/test/__setup.js
+++ b/test/__setup.js
@@ -1,7 +1,9 @@
+'use strict';
+
 // This file is name __setup so that it gets loaded first
 // and performs initialization for tests
-require('co-mocha')
+require('co-mocha');
 
 // effectivley silence the logging
-var logger = (require ('../lib/logger')).getLogger();
+var logger = (require('../lib/logger')).getLogger();
 logger._level = Number.POSITIVE_INFINITY;

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,12 +1,14 @@
+'use strict';
+
 var request = require('supertest');
 
 var Server = require('../lib/api/server');
 var server = null;
 
-describe("auth", function(){
-  this.timeout(1000)
+describe('auth', function() {
+  this.timeout(1000);
 
-  before("start server", function (done){
+  before('start server', function(done) {
     var testConf = {
       tokens: ['tik', 'tok'],
       server: {
@@ -25,35 +27,35 @@ describe("auth", function(){
     loom.listen(done);
     // Get a reference to the restify server.
     server = loom.server;
-  })
+  });
 
-  describe("all endpoints require auth", function(){
-    it("GET /spy", function (done){
+  describe('all endpoints require auth', function() {
+    it('GET /spy', function(done) {
       request(server)
         .get('/spy')
         .expect('Content-Type', /json/)
-        .expect(401, done)
+        .expect(401, done);
     });
 
-    it("GET /stream/id", function (done){
+    it('GET /stream/id', function(done) {
       request(server)
         .get('/stream/id')
         .expect('Content-Type', /json/)
-        .expect(401, done)
+        .expect(401, done);
     });
 
-    it("POST /stream/id", function (done){
+    it('POST /stream/id', function(done) {
       request(server)
         .post('/stream/id')
         .expect('Content-Type', /json/)
-        .expect(401, done)
+        .expect(401, done);
     });
 
-    it("POST /stream/", function (done){
+    it('POST /stream/', function(done) {
       request(server)
         .post('/stream')
         .expect('Content-Type', /json/)
-        .expect(401, done)
+        .expect(401, done);
     });
   });
 });

--- a/test/file_storage.js
+++ b/test/file_storage.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/* eslint guard-for-in: 0 */
+
+var fs = require('fs');
+
+var bl = require('bl');
+var temp = require('temp').track();
+var FileSystemStorage = require('../lib/models').FileSystemStorage;
+
+var config = {
+  dataDir: temp.mkdirSync(),
+  // keep tail timeout low so that we don't time out the test
+  tailTimeout: 1000,
+};
+
+describe('FileSystemStorage', function() {
+  before(function* reset() {
+    // configure and reset DB
+    var config = {
+      db: process.env.DB_NAME || 'test',
+    };
+    var rethink = require('../lib/rethink');
+    rethink.connect(config);
+    yield [rethink.models.Logs.delete(), rethink.models.Meta.delete()];
+  });
+
+  it('constructs an instance properly', function() {
+    var instance;
+    instance = new FileSystemStorage();
+    instance.config.should.containEql({
+      metaTable: 'meta',
+      dataDir: 'data',
+    });
+
+    var conf = {dataDir: 'custom_dir', metaTable: 'custom table'};
+    instance = new FileSystemStorage(conf);
+
+    // ensure config argument is not modified
+    conf.should.eql({dataDir: 'custom_dir', metaTable: 'custom table'});
+
+    instance.config.should.containEql({
+      metaTable: 'custom table',
+      dataDir: 'custom_dir',
+    });
+  });
+
+  it('generates file names properly', function() {
+    var instance = new FileSystemStorage(config);
+
+    instance.makeFileName('stream-x-1').should.eql('stream-stream-x-1.log');
+    instance.makeStreamFilePath('stream-x-2').should.eql(`${config.dataDir}/stream-stream-x-2.log`);
+  });
+
+  it('writes to a file', function(done) {
+    var instance = new FileSystemStorage(config);
+
+    var writeStream = instance.createWriteStream('xyz');
+    writeStream.write('line 1\n');
+    writeStream.write('line 2\n');
+    writeStream.end('this is the end\n');
+
+    writeStream.on('finish', () => {
+      fs.readFileSync(`${config.dataDir}/stream-xyz.log`).toString()
+        .should.eql(`line 1
+line 2
+this is the end
+`);
+
+      done();
+    });
+  });
+
+  it('reads from a file (notail)', function(done) {
+    var instance = new FileSystemStorage(config);
+
+    var fileContents = `write test line 1
+write test line 2
+write test end
+`;
+
+    fs.writeFileSync(`${config.dataDir}/stream-abc.log`, fileContents);
+
+    var reader = instance.createReadStream('abc', {notail: true});
+
+    reader.pipe(bl(function(err, data) {
+      if (err) return done(err);
+      data.toString().should.eql(fileContents);
+    }));
+
+    reader.on('end', () => {
+      done();
+    });
+  });
+
+  it('reads from a file (default)', function(done) {
+    var instance = new FileSystemStorage(config);
+
+    var fileContents = `write test line 1
+write test line 2
+write test end
+`;
+
+    fs.writeFileSync(`${config.dataDir}/stream-tail.log`, fileContents);
+    setTimeout(() => fs.appendFile(`${config.dataDir}/stream-tail.log`, 'new content'), 200);
+
+    var reader = instance.createReadStream('tail');
+
+    var start = +new Date();
+
+    reader.pipe(bl(function(err, data) {
+      if (err) return done(err);
+      data.toString().should.eql(fileContents + 'new content');
+    }));
+
+    reader.on('end', () => {
+      var end = +new Date();
+      (end - start).should.approximately(1000 + 200, 10);
+
+      done();
+    });
+  });
+
+  it('deletes files', function(done) {
+    var instance = new FileSystemStorage(config);
+
+    fs.writeFileSync(`${config.dataDir}/stream-deleteme.log`, 'to be deleted');
+
+    instance.deleteStream('deleteme', function(err, renamed) {
+      if (err) done(err);
+
+      // make sure orignal file exists but is renamed
+      (function() {
+        fs.statSync(`${config.dataDir}/stream-deleteme.log`);
+      }).should.throw(/ENOENT: no such file or directory/);
+
+      // does not throw if exists
+      fs.statSync(renamed);
+
+      renamed.should.match(new RegExp(`${config.dataDir}/deleted_[0-9]+_stream-deleteme.log`));
+
+      done();
+    });
+  });
+
+});

--- a/test/models.js
+++ b/test/models.js
@@ -10,6 +10,10 @@ var ArrayStreamStorage = require('../lib/models').ArrayStreamStorage;
 var RethinkStorage = require('../lib/models').RethinkStorage;
 var FileSystemStorage = require('../lib/models').FileSystemStorage;
 
+function isDescendant(B, A) {
+  return B.prototype instanceof A || B === A;
+}
+
 function testStorage(Storage, storageConfig) {
   function read(streamid, storage) {
     return (storage || new Storage(storageConfig)).createReadStream(streamid);
@@ -21,7 +25,7 @@ function testStorage(Storage, storageConfig) {
 
   describe('Storage: ' + Storage.name, function() {
     before(function* reset() {
-      if (Storage === RethinkStorage || Storage === FileSystemStorage) {
+      if (isDescendant(Storage, RethinkStorage)) {
         // configure and reset DB
         var config = {
           db: process.env.DB_NAME || 'test',

--- a/test/models.js
+++ b/test/models.js
@@ -1,155 +1,156 @@
-var through = require('through2')
-var bl = require('bl')
-var ArrayStreamStorage = require('../lib/models').ArrayStreamStorage
-var RethinkStorage = require('../lib/models').RethinkStorage
+'use strict';
 
-function test_storage(Storage){
-  function read(streamid, storage){
-    return (storage || new Storage()).createReadStream(streamid)
+/* eslint guard-for-in: 0 */
+
+var through = require('through2');
+var bl = require('bl');
+var ArrayStreamStorage = require('../lib/models').ArrayStreamStorage;
+var RethinkStorage = require('../lib/models').RethinkStorage;
+
+function testStorage(Storage) {
+  function read(streamid, storage) {
+    return (storage || new Storage()).createReadStream(streamid);
   }
 
-  function write(streamid, storage){
-    return (storage || new Storage()).createWriteStream(streamid)
+  function write(streamid, storage) {
+    return (storage || new Storage()).createWriteStream(streamid);
   }
 
-  describe("Storage: " + Storage.name, function (){
-    before(function* reset(){
-      if(Storage === RethinkStorage){
+  describe('Storage: ' + Storage.name, function() {
+    before(function* reset() {
+      if (Storage === RethinkStorage) {
         // configure and reset DB
         var config = {
-          db: process.env.DB_NAME || "test"
-        }
-        var rethink = require('../lib/rethink')
-        rethink.connect(config)
-        yield [rethink.models.Logs.delete(), rethink.models.Meta.delete()]
+          db: process.env.DB_NAME || 'test',
+        };
+        var rethink = require('../lib/rethink');
+        rethink.connect(config);
+        yield [rethink.models.Logs.delete(), rethink.models.Meta.delete()];
       }
-    })
+    });
 
-    describe("storage basics", function (){
+    describe('storage basics', function() {
       var streams = {
         'stream 1': {some: 'data'},
-        'stream 2': {more: 'data'}
-      }
+        'stream 2': {more: 'data'},
+      };
 
-      it("creates streams", function* (){
-        var storage = new Storage()
-        for(var streamid in streams){
-          var meta = yield storage.saveStream(streamid, streams[streamid])
-          // switch(streamid){
-          // case 'stream 1':
-          //   meta.should.eql({some: "data"})
-          //   break;
-          // case 'stream 2':
-          //   meta.should.eql({more: "data"})
-          //   break;
-          // }
+      it('creates streams', function* () {
+        var storage = new Storage();
+        for (var streamid in streams) {
+          yield storage.saveStream(streamid, streams[streamid]);
         }
-      })
+      });
 
-      it("loads streams", function* (){
-        var storage = new Storage()
-        var meta = yield storage.loadStream(Object.keys(streams)[0])
-        meta.should.eql({some: "data"})
-      })
+      it('loads streams', function* () {
+        var storage = new Storage();
+        var meta = yield storage.loadStream(Object.keys(streams)[0]);
+        meta.should.eql({some: 'data'});
+      });
 
-      it("stream 1 writes then reads", function(done){
-        var storage = new Storage()
-        var list = bl()
-        list.append("some data")
-        list.append("more data")
+      it('stream 1 writes then reads', function(done) {
+        var storage = new Storage();
+        var list = bl();
+        list.append('some data');
+        list.append('more data');
 
-        var streamid = 'stream 1'
-        var writer = write(streamid, storage)
-        list.duplicate().pipe(writer)
+        var streamid = 'stream 1';
+        var writer = write(streamid, storage);
+        list.duplicate().pipe(writer);
 
-        writer.on("finish", function(){
-          var reader = read(streamid, storage)
-          reader.pipe(bl(function(err, data){
-            if(err) return done(err)
-            data.should.eql(list.slice(), 'reader on same storage as writer works')
-          }))
+        writer.on('finish', function() {
+          var reader = read(streamid, storage);
+          reader.pipe(bl(function(err, data) {
+            if (err) return done(err);
+            data.should.eql(list.slice(), 'reader on same storage as writer works');
+          }));
 
-          reader.on('end', function(){
-            read(streamid).pipe(bl(function(err, data){
-              if(err) return done(err)
-              data.should.eql(list.slice(), 'reader on different storage than writer works')
+          reader.on('end', function() {
+            read(streamid).pipe(bl(function(err, data) {
+              if (err) return done(err);
+              data.should.eql(list.slice(), 'reader on different storage than writer works');
 
-              done()
-            }))
-          })
-        })
-      })
+              done();
+            }));
+          });
+        });
+      });
 
-      it("stream 2 writes and reads async", function(done){
-        var expected, num = 10, interval = 100
-        var producer = makeProducer(num, interval, function finished_producing(data){
-          expected = data
-        })
+      it('stream 2 writes and reads async', function(done) {
+        var expected;
+        var num = 10;
+        var interval = 100;
+        var producer = makeProducer(num, interval, function finishedProducing(data) {
+          expected = data;
+        });
 
-        producer.pipe(write('stream 2'))
+        producer.pipe(write('stream 2'));
 
-        var immediate_finished = false
-        var delayed_finished = false
+        var immediateFinished = false;
+        var delayedFinished = false;
 
         // reader that starts reading immediately (full stream mode)
-        read('stream 2').pipe(bl(function(err, data){
+        read('stream 2').pipe(bl(function(err, data) {
           // console.log("expected:", expected.toString())
           // console.log("found   :", data.toString())
 
-          data.toString().should.eql(expected.toString())
-          immediate_finished = true
+          data.toString().should.eql(expected.toString());
+          immediateFinished = true;
 
-          if(delayed_finished && immediate_finished)
-            done()
-        }))
+          if (delayedFinished && immediateFinished) {
+            done();
+          }
+        }));
 
         // reader that starts listenting half way (partial stream mode)
         // gets existing data, then listens for changes
-        setTimeout(function(){
-          read('stream 2').pipe(bl(function(err, data){
+        setTimeout(function() {
+          read('stream 2').pipe(bl(function(err, data) {
             // console.log("expected:", expected.toString())
             // console.log("found   :", data.toString())
 
-            data.toString().should.eql(expected.toString())
+            data.toString().should.eql(expected.toString());
 
-            delayed_finished = true
+            delayedFinished = true;
 
-            if(delayed_finished && immediate_finished)
-              done()
-          }))
-        }, num*interval/2)
-      })
-    })
-  })
+            if (delayedFinished && immediateFinished) {
+              done();
+            }
+          }));
+        }, num * interval / 2);
+      });
+    });
+  });
 }
 
-test_storage(ArrayStreamStorage)
-test_storage(RethinkStorage)
+testStorage(ArrayStreamStorage);
+testStorage(RethinkStorage);
 
-function makeProducer(numpushes, interval, finished){
-  numpushes = numpushes || 2
-  interval = interval || 100
+function makeProducer(numpushes, interval, finished) {
+  numpushes = numpushes || 2;
+  interval = interval || 100;
 
-  var producer = through()
+  var producer = through();
 
-  var data = []
+  var data = [];
 
-  var pushed = 0
-  var _i = setInterval(function(){
-    if(pushed >= numpushes){
-      clearInterval(_i)
-      producer.end()
-    } else {
-      var d = new Buffer("data " + ++pushed)
-      data.push(d)
-      producer.write(d)
+  var pushed = 0;
+  var _i = setInterval(function() {
+    if (pushed >= numpushes) {
+      clearInterval(_i);
+      producer.end();
     }
-  }, interval)
+    else {
+      var d = new Buffer('data ' + ++pushed);
+      data.push(d);
+      producer.write(d);
+    }
+  }, interval);
 
-  if(finished){
-    producer.on('finish', function(){
-      finished && finished(Buffer.concat(data))
-    })
+  if (finished) {
+    producer.on('finish', function() {
+      if (finished) { finished(Buffer.concat(data)); }
+    });
   }
-  return producer
+  return producer;
 }

--- a/test/models.js
+++ b/test/models.js
@@ -136,6 +136,7 @@ testStorage(FileSystemStorage, {
   dataDir: temp.mkdirSync(),
   // keep tail timeout low so that we don't time out the test
   tailTimeout: 1000,
+  compress: false,
 });
 
 function makeProducer(numpushes, interval, finished) {

--- a/test/server.js
+++ b/test/server.js
@@ -1,17 +1,18 @@
-var util = require('util')
-var http = require('http')
-var url = require('url')
+'use strict';
+
+var http = require('http');
+var url = require('url');
 
 // var should = require('should')
 
-var Server = require('../lib/api/server')
-var rethink = require('../lib/rethink')
+var Server = require('../lib/api/server');
+var rethink = require('../lib/rethink');
 
-var numChunks = 4
-var consumerWait = 2000
+var numChunks = 4;
+var consumerWait = 2000;
 var server = null;
 
-function start(cb){
+function start(cb) {
   var testConf = {
     tokens: ['tik', 'tok'],
     server: {
@@ -26,90 +27,89 @@ function start(cb){
       metaTable: 'meta',
     },
   };
-  loom = new Server(testConf);
+  var loom = new Server(testConf);
   // Get a reference to the restify server.
   server = loom.server;
   loom.listen(0, '127.0.0.1', function() {
-    server.url = `http://localhost:${server.address().port}`
-    server.log.info('%s listening at %s', server.name, server.url)
-    cb && cb()
+    server.log.info('%s listening at %s', server.name, server.url);
+    return cb && cb();
   });
 }
 
-describe("server", function(){
-  before("clear database", function* (){
-    yield [rethink.models.Logs.delete(), rethink.models.Meta.delete()]
-  })
+describe('server', function() {
+  before('clear database', function* () {
+    yield [rethink.models.Logs.delete(), rethink.models.Meta.delete()];
+  });
 
-  before("server starts", function (done){
-    start(done)
-  })
+  before('server starts', function(done) {
+    start(done);
+  });
 
-  describe("producer", function(){
-    var streamId
+  describe('producer', function() {
+    var streamId;
 
-    function start_consumer(id, cb){
-      console.log("starting consumer")
+    function startConsumer(id, cb) {
+      console.log('starting consumer');
 
-      var data = []
+      var data = [];
 
-      var consumer_handler = function(res){
+      var consumerHandler = function(res) {
         console.log('CONSUMER STATUS: ' + res.statusCode);
         console.log('CONSUMER HEADERS: ' + JSON.stringify(res.headers));
         res.setEncoding('utf8');
-        res.on('data', function (chunk) {
+        res.on('data', function(chunk) {
           console.log('CONSUMER BODY: ' + chunk);
-          data.push(chunk)
+          data.push(chunk);
         });
-        res.on("end", function(){
-          console.log("CONSUMER has read the full stream")
+        res.on('end', function() {
+          console.log('CONSUMER has read the full stream');
 
           data.should.eql([
             'chunks written 4',
             'chunks written 3',
             'chunks written 2',
-            'chunks written 1'
-          ])
+            'chunks written 1',
+          ]);
 
-          setTimeout(cb, 1000)
-        })
-        res.on("error", function(err){
-          console.log("CONSUMER error", err)
-          cb(err)
-        })
-      }
+          setTimeout(cb, 1000);
+        });
+        res.on('error', function(err) {
+          console.log('CONSUMER error', err);
+          cb(err);
+        });
+      };
 
       var consumer = http.request({
         hostname: 'localhost',
         port: url.parse(server.url).port,
         path: '/stream/' + id,
         headers: {
-          authorization: 'bearer tik'
-        }
-      }, consumer_handler)
-      consumer.end()
+          authorization: 'bearer tik',
+        },
+      }, consumerHandler);
+      consumer.end();
     }
 
-    it("feeds data", function (done){
-      var producer_handler = function(res){
+    it('feeds data', function(done) {
+      var producerHandler = function(res) {
         console.log('PRODUCER STATUS: ' + res.statusCode);
         console.log('PRODUCER HEADERS: ' + JSON.stringify(res.headers));
         res.setEncoding('utf8');
-        res.on('data', function (chunk) {
+        res.on('data', function(chunk) {
           console.log('PRODUCER BODY: ' + chunk);
         });
         // res.on("end", done)
 
         // start the consumer for our stream id
-        streamId = res.headers['x-stream-id']
-        setTimeout(function(){
-          start_consumer(streamId, done)
-        }, consumerWait)
+        streamId = res.headers['x-stream-id'];
+        setTimeout(function() {
+          startConsumer(streamId, done);
+        }, consumerWait);
 
         console.log(`
 curl -vi --no-buffer http://:::${server.address().port}/stream/${streamId}
-`)
-      }
+`);
+      };
 
       var producer = http.request({
         hostname: 'localhost',
@@ -117,28 +117,29 @@ curl -vi --no-buffer http://:::${server.address().port}/stream/${streamId}
         method: 'post',
         path: '/stream',
         headers: {
-          authorization: 'bearer tik',
-          connection: 'keep-alive',
-          'x-stream-metadata': JSON.stringify({test_stream: true})
-        }
-      }, producer_handler)
+          'authorization': 'bearer tik',
+          'connection': 'keep-alive',
+          'x-stream-metadata': JSON.stringify({test_stream: true}),
+        },
+      }, producerHandler);
 
       // stream some data
-      var chunks = numChunks
-      var i = setInterval(function(){
-        if(chunks > 0){
-          producer.write("chunks written " + chunks)
-          console.log("producer sending data", chunks)
-          chunks--
-        } else {
-          clearInterval(i)
-          producer.end()
+      var chunks = numChunks;
+      var i = setInterval(function() {
+        if (chunks > 0) {
+          producer.write('chunks written ' + chunks);
+          console.log('producer sending data', chunks);
+          chunks--;
         }
-      }, 1000)
-    })
+        else {
+          clearInterval(i);
+          producer.end();
+        }
+      }, 1000);
+    });
 
-    it("has complete data", function (done){
-      start_consumer(streamId, done)
-    })
-  })
-})
+    it('has complete data', function(done) {
+      startConsumer(streamId, done);
+    });
+  });
+});


### PR DESCRIPTION
Created a storage backend (used by default now) that uses the filesystem for stream storage. Metadata is still stored and searched in Rethink. There's also transparent gzip compression for the files stored on disk.

There's a tricky point around knowing when the stream has ended or not. With Rethink, we had a clear data terminator (`null` value), but with files we don't have this. I considered adding a well-known termination string, but decided against it because detecting it in arbitrary streams would be too complicated. We could line-delimit stream contents, but that won't work for binary streams (if there are any).

The other option was to store stream status in the stream meta-data object. But this would require a larger refactoring of how the system works, so I opted against it.

What's implemented is an algorithm the checks the modified timestamp of the stream file, and uses a `tailTimeout`. If the file has been written to recently, we keep tailing it in a read stream and wait for `tailTimeout`. If the file's last write is older then `tailTimeout` at the time that the read stream is started, we assume that the stream is complete and close the stream after reading full file contents. This seems like a good compromise between functionality and development effort.

**Note: There's a change in the config file:**

```
dbLogsTable: "logs"
dbMetaTable: "meta"
```

is now

```
storageMetaTable: "meta"
storageLogsTable: "logs"
```

to better reflect the modular nature of storage backends.

The following config params are added for the filesystem storage backend (none of these are set by default in `default.yaml`). The only param that needs to be set for production is `storageDataDir`, others can keep defaults.

```
# Path on file system for storing stream files. Defaults to "data"
storageDataDir: "data"

# Timeout for tailing streams. Defaults to 30 seconds.
storageTailTimeout: 30s

# File compression, defaults to true
storageCompress: true
```

**Migration**

To migrate the streams from the database to the file system, run:

```
node migrations/0001-rethink-to-file-streams.js -c config.yaml | tee migration.log | bunyan
```

The migration script will save every stream to the file system one at a time.

Do **not** restart the service after the upgrade.
Run the migration **after** the upgrade to this branch.
Then restart the service to switch storage to filesystem mode.
