### PR TITLE
Comment out the default tokens 

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -26,6 +26,6 @@ storageLogsTable: "logs"
 
 
 # API tokens
-tokens:
-  - tik
-  - tok
+#tokens:
+#  - tik
+#  - tok


### PR DESCRIPTION
so they are not part of the Open Source configuration by default (security).