### PR TITLE
A key README mispelling that snagged me for hours.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tokens:
 To authenticate API calls use a bearer-token authentication header: `Authentication: Bearer token1`
 
 ```
-curl -H "Authentication: Bearer token1" http://localhost:3060/stream/test
+curl -H "Authorization: Bearer token1" http://localhost:3060/stream/test
 ```
 
 ## Producers


### PR DESCRIPTION
The header is Authorization not Authentication.